### PR TITLE
file-name-handler-alist double-null — correctness bug, can break TRAMP and compressed files

### DIFF
--- a/init.org
+++ b/init.org
@@ -359,13 +359,6 @@ Famously, the Emacs garbage collector can impede startup times quite dramaticall
 
 ** Optimisations
 
-We can set the =file-name-handler-alist=, which is supposed to help startup times a little.
-
-#+begin_src emacs-lisp
-(setq file-name-handler-alist-original file-name-handler-alist)
-(setq file-name-handler-alist nil)
-#+end_src
-
 I also get quite a lot of compilation warnings, especially from native compilation, but they are usually safe to ignore.
 
 #+begin_src emacs-lisp


### PR DESCRIPTION
The init.el copy runs after early-init.el has already restored it, then nulls it permanently. This means file-name-handler-alist stays empty after startup, which can break remote file access (TRAMP), compressed file handling, and other handlers that legitimately need to run at runtime. The init.el block should be removed entirely — early-init.el already handles this correctly.

;; early-init.el
(defvar file-name-handler-alist-old file-name-handler-alist) 
(setq file-name-handler-alist nil)
(add-hook 'emacs-startup-hook
          (lambda ()
              (setq file-name-handler-alist file-name-handler-alist-old)))


;; init.el — nulls it again, no restore
(setq file-name-handler-alist-original file-name-handler-alist) 
(setq file-name-handler-alist nil)