### PR TITLE
auto-dark hook is broken

### DIFF
--- a/init.org
+++ b/init.org
@@ -1001,7 +1001,7 @@ For some reason, my light themes leave some fragments that disappear when I load
                `(eval-sexp-fu-flash
                  ((t (:background
                       ,soph/default-dark-accent-colour)))))
-              `(load-theme ,soph/default-dark-theme t))))
+              (load-theme soph/default-dark-theme t))))
          (auto-dark-light-mode
           .
           (lambda ()
@@ -1011,7 +1011,7 @@ For some reason, my light themes leave some fragments that disappear when I load
                `(eval-sexp-fu-flash
                  ((t (:background
                       ,soph/default-light-accent-colour)))))
-              `(load-theme ,soph/default-light-theme t)))))
+              (load-theme soph/default-light-theme t)))))
   :custom
   (auto-dark-themes                   `((,soph/default-dark-theme) (,soph/default-light-theme)))
   (auto-dark-polling-interval-seconds 5)


### PR DESCRIPTION
The backtick makes this a quoted list — it constructs the list (load-theme doom-nord t) but never calls it. The theme never actually switches. The custom-set-faces call runs fine, but the theme load silently does nothing. It should be (load-theme soph/default-dark-theme t) without the backtick.