### PR TITLE
smartparens :bind parenthesis mismatch

### DIFF
--- a/init.org
+++ b/init.org
@@ -3386,9 +3386,9 @@ It's a bit insane to pull in lispy just for these functions, but I've really gro
               ("("           . lispy-parens)
               (")"           . lispy-right-nostring)
               ("["           . lispy-brackets)
-              ("]"           . lispy-close-square))
+              ("]"           . lispy-close-square)
               ("{"           . lispy-braces)
-              ("}"           . lispy-close-curly))
+              ("}"           . lispy-close-curly)))
 #+end_src
 
 ** LSP


### PR DESCRIPTION
The )) after lispy-close-square closes the :map block and the use-package :bind argument. The { and } entries are bare expressions at top level, outside the use-package form. This will either cause a load error or silently drop both bindings.